### PR TITLE
[ENH] Make root path for app configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Other helpful tools for interfacing with Neurobagel
 2. Create a .env file with the following variables:
     - `NB_BOT_ID`: the **app ID** of the Neurobagel Bot app, which you can find on the [settings page for the app](https://docs.github.com/en/apps/maintaining-github-apps/modifying-a-github-app-registration#navigating-to-your-github-app-settings)
     - `HOST_NB_BOT_KEY_PATH`: the path to the private key file on your machine (if not provided, will default to `./private_key.pem`)
-    - (OPTIONAL) `NB_UPLOADER_API_ROOT_PATH`: if using a proxy server that serves this app from a path/subdirectory, the path prefix declared for this app (that will be stripped by the proxy), e.g., `/upload`. \ 
+    - (OPTIONAL) `NB_UPLOADER_API_ROOT_PATH`: if using a proxy server that serves this app from a path/subdirectory, the path prefix declared for this app (that will be stripped by the proxy), e.g., `/upload`.  
     ⚠️ **Should not include a trailing slash!** 
 3. Navigate to the root of the repository and run:
     ```bash

--- a/README.md
+++ b/README.md
@@ -13,8 +13,8 @@ Other helpful tools for interfacing with Neurobagel
 2. Create a .env file with the following variables:
     - `NB_BOT_ID`: the **app ID** of the Neurobagel Bot app, which you can find on the [settings page for the app](https://docs.github.com/en/apps/maintaining-github-apps/modifying-a-github-app-registration#navigating-to-your-github-app-settings)
     - `HOST_NB_BOT_KEY_PATH`: the path to the private key file on your machine (if not provided, will default to `./private_key.pem`)
-    - (OPTIONAL) `NB_UPLOADER_API_ROOT_PATH`: if using a proxy server that serves this app from a path/subdirectory, the path prefix declared for this app (that will be stripped by the proxy), e.g., `/upload`. 
-    **Should not include a trailing slash!** 
+    - (OPTIONAL) `NB_UPLOADER_API_ROOT_PATH`: if using a proxy server that serves this app from a path/subdirectory, the path prefix declared for this app (that will be stripped by the proxy), e.g., `/upload`. \ 
+    ⚠️ **Should not include a trailing slash!** 
 3. Navigate to the root of the repository and run:
     ```bash
     docker compose up -d

--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
-[![codecov](https://codecov.io/gh/neurobagel/tools/graph/badge.svg?token=3E2e6vNiih)](https://codecov.io/gh/neurobagel/tools)
-[![Python versions](https://img.shields.io/badge/python-3.10-4682B4?style=flat)](https://www.python.org)
-[![License](https://img.shields.io/github/license/neurobagel/tools?color=CD5C5C&style=flat)](LICENSE)
+[![Main branch checks status](https://img.shields.io/github/check-runs/neurobagel/tools/main)](https://github.com/neurobagel/tools/actions?query=branch:main)
+[![Tests status](https://img.shields.io/github/actions/workflow/status/neurobagel/tools/test.yml?branch=main&label=tests)](https://github.com/neurobagel/tools/actions/workflows/test.yml)
+[![Codecov](https://img.shields.io/codecov/c/github/neurobagel/tools?logo=codecov&link=https%3A%2F%2Fcodecov.io%2Fgh%2Fneurobagel%2Ftools)](https://codecov.io/gh/neurobagel/tools)
+[![Python versions static](https://img.shields.io/badge/python-3.10-blue?logo=python)](https://www.python.org)
+[![License](https://img.shields.io/github/license/neurobagel/tools?color=purple&link=https%3A%2F%2Fgithub.com%2Fneurobagel%2Ftools%2Fblob%2Fmain%2FLICENSE)](LICENSE)
+[![Docker Image Version (tag)](https://img.shields.io/docker/v/neurobagel/openneuro_upload/latest?logo=docker&link=https%3A%2F%2Fhub.docker.com%2Fr%2Fneurobagel%2Fopenneuro_upload%2Ftags)](https://hub.docker.com/r/neurobagel/openneuro_upload/tags)
 
 # tools
 Other helpful tools for interfacing with Neurobagel

--- a/README.md
+++ b/README.md
@@ -7,9 +7,11 @@ Other helpful tools for interfacing with Neurobagel
 
 ## Steps to deploy
 1. Create a file containing a [private key](https://docs.github.com/en/apps/creating-github-apps/authenticating-with-a-github-app/managing-private-keys-for-github-apps) for the Neurobagel Bot app
-2. Create a .env file with two variables:
+2. Create a .env file with the following variables:
     - `NB_BOT_ID`: the **app ID** of the Neurobagel Bot app, which you can find on the [settings page for the app](https://docs.github.com/en/apps/maintaining-github-apps/modifying-a-github-app-registration#navigating-to-your-github-app-settings)
     - `HOST_NB_BOT_KEY_PATH`: the path to the private key file on your machine (if not provided, will default to `./private_key.pem`)
+    - (OPTIONAL) `NB_UPLOADER_API_ROOT_PATH`: if using a proxy server that serves this app from a path/subdirectory, the path prefix declared for this app (that should be stripped by the proxy), e.g., `/upload`. 
+    **Should not include a trailing slash!** 
 3. Navigate to the root of the repository and run:
     ```bash
     docker compose up -d

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Other helpful tools for interfacing with Neurobagel
 2. Create a .env file with the following variables:
     - `NB_BOT_ID`: the **app ID** of the Neurobagel Bot app, which you can find on the [settings page for the app](https://docs.github.com/en/apps/maintaining-github-apps/modifying-a-github-app-registration#navigating-to-your-github-app-settings)
     - `HOST_NB_BOT_KEY_PATH`: the path to the private key file on your machine (if not provided, will default to `./private_key.pem`)
-    - (OPTIONAL) `NB_UPLOADER_API_ROOT_PATH`: if using a proxy server that serves this app from a path/subdirectory, the path prefix declared for this app (that should be stripped by the proxy), e.g., `/upload`. 
+    - (OPTIONAL) `NB_UPLOADER_API_ROOT_PATH`: if using a proxy server that serves this app from a path/subdirectory, the path prefix declared for this app (that will be stripped by the proxy), e.g., `/upload`. 
     **Should not include a trailing slash!** 
 3. Navigate to the root of the repository and run:
     ```bash

--- a/app/api/utility.py
+++ b/app/api/utility.py
@@ -6,6 +6,7 @@ from typing import Union
 
 from .models import Contributor
 
+ROOT_PATH = os.environ.get("NB_UPLOADER_API_ROOT_PATH", "")
 # TODO: Error out when these variables are not set?
 APP_ID = os.environ.get("NB_BOT_ID")
 APP_PRIVATE_KEY_PATH = os.environ.get("NB_BOT_KEY_PATH")

--- a/app/main.py
+++ b/app/main.py
@@ -48,7 +48,7 @@ def root(request: Request):
     <html>
         <body>
             <h1>Welcome to the API for <a href="https://github.com/OpenNeuroDatasets-JSONLD" target="_blank">Neurobagel-annotated OpenNeuro Datasets!</a></h1>
-            <p>Please visit the <a href="{request.scope.get("root_path", "")}/docs">documentation</a> to view available API endpoints.</p>
+            <p>Please visit the <a href="{request.scope.get("root_path", "")}/docs">API documentation</a> to view available API endpoints.</p>
         </body>
     </html>
     """

--- a/app/main.py
+++ b/app/main.py
@@ -1,12 +1,12 @@
 from contextlib import asynccontextmanager
 
 import uvicorn
-from fastapi import FastAPI
+from fastapi import FastAPI, Request
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.openapi.docs import get_redoc_html, get_swagger_ui_html
 from fastapi.responses import HTMLResponse, ORJSONResponse, RedirectResponse
 
-from app.api.utility import set_gh_credentials
+from app.api.utility import ROOT_PATH, set_gh_credentials
 
 from .api.routers import openneuro
 
@@ -21,6 +21,7 @@ async def lifespan(app: FastAPI):
 
 
 app = FastAPI(
+    root_path=ROOT_PATH,
     default_response_class=ORJSONResponse,
     lifespan=lifespan,
     # We will override the default docs with our own endpoints with a custom favicon
@@ -39,15 +40,15 @@ app.add_middleware(
 
 # TODO: Should we exclude the root endpoint from the schema for a cleaner docs?
 @app.get("/", response_class=HTMLResponse)
-def root():
+def root(request: Request):
     """
     Display a welcome message and a link to the API documentation.
     """
-    return """
+    return f"""
     <html>
         <body>
             <h1>Welcome to the API for <a href="https://github.com/OpenNeuroDatasets-JSONLD" target="_blank">Neurobagel-annotated OpenNeuro Datasets!</a></h1>
-            <p>Please visit the <a href="/docs">documentation</a> to view available API endpoints.</p>
+            <p>Please visit the <a href="{request.scope.get("root_path", "")}/docs">documentation</a> to view available API endpoints.</p>
         </body>
     </html>
     """
@@ -62,24 +63,24 @@ async def favicon():
 
 
 @app.get("/docs", include_in_schema=False)
-def overridden_swagger():
+def overridden_swagger(request: Request):
     """
     Overrides the Swagger UI HTML for the "/docs" endpoint.
     """
     return get_swagger_ui_html(
-        openapi_url="/openapi.json",
+        openapi_url=f"{request.scope.get('root_path', '')}/openapi.json",
         title="Neurobagel OpenNeuro Datasets API",
         swagger_favicon_url=FAVICON_URL,
     )
 
 
 @app.get("/redoc", include_in_schema=False)
-def overridden_redoc():
+def overridden_redoc(request: Request):
     """
     Overrides the Redoc HTML for the "/redoc" endpoint.
     """
     return get_redoc_html(
-        openapi_url="/openapi.json",
+        openapi_url=f"{request.scope.get('root_path', '')}/openapi.json",
         title="Neurobagel OpenNeuro Datasets API",
         redoc_favicon_url=FAVICON_URL,
     )

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,7 @@ services:
       # Note: Having the private key in a separate file vs. an environment variable avoids issues with newlines in the key and minimizes exposure
       - "${HOST_NB_BOT_KEY_PATH:-./private_key.pem}:/etc/keys/private_key.pem:ro"
     environment:
+      NB_UPLOADER_API_ROOT_PATH: ${NB_UPLOADER_API_ROOT_PATH:-""}
       NB_BOT_ID: "${NB_BOT_ID}"
       # This variable used by the app can be overridden if needed during development
       NB_BOT_KEY_PATH: "/etc/keys/private_key.pem"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-anyio==3.6.2
+anyio==3.7.1
 attrs==23.1.0
 certifi==2023.7.22
 cffi==1.17.1
@@ -11,7 +11,7 @@ cryptography==43.0.1
 Deprecated==1.2.14
 distlib==0.3.6
 exceptiongroup==1.0.4
-fastapi==0.95.2
+fastapi==0.115.4
 filelock==3.8.0
 h11==0.14.0
 httpcore==0.16.2
@@ -47,10 +47,10 @@ rfc3986==1.5.0
 rpds-py==0.13.2
 six==1.16.0
 sniffio==1.3.0
-starlette==0.27.0
+starlette==0.41.3
 toml==0.10.2
 tomli==2.0.1
-typing_extensions==4.4.0
+typing_extensions==4.12.2
 urllib3==2.2.1
 uvicorn==0.20.0
 virtualenv==20.16.7

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -64,7 +64,7 @@ def test_docs_when_root_path_includes_trailing_slash(
     This provides a sanity check that the app does not ignore/redirect trailing slashes in the root_path when requests are received.
     """
 
-    monkeypatch.setattr(app, "root_path", "/upload")
+    monkeypatch.setattr(app, "root_path", "/upload/")
     docs_response = test_app.get(f"{test_path}/docs", follow_redirects=False)
     schema_response = test_app.get(
         f"{test_path}/openapi.json", follow_redirects=False

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -1,0 +1,73 @@
+import pytest
+from fastapi import status
+
+from app.main import app
+
+
+@pytest.mark.parametrize(
+    "path",
+    ["/", ""],
+)
+def test_root(test_app, path, monkeypatch):
+    """Given a GET request to the root endpoint, Check for 200 status and expected content."""
+
+    monkeypatch.setattr(app, "root_path", "")
+    response = test_app.get(path, follow_redirects=False)
+
+    assert response.status_code == status.HTTP_200_OK
+    assert all(
+        substring in response.text
+        for substring in [
+            "Neurobagel-annotated OpenNeuro Datasets",
+            '<a href="/docs">API documentation</a>',
+        ]
+    )
+
+
+@pytest.mark.parametrize(
+    "test_path,expected_status_code",
+    [("", 200), ("/upload", 200), ("/wrongroot", 404)],
+)
+def test_docs_work_using_defined_root_path(
+    test_app, test_path, expected_status_code, monkeypatch
+):
+    """
+    Test that when the API root_path is set to a non-empty string,
+    the interactive docs and OpenAPI schema are only reachable with the correct path prefix
+    (e.g., mimicking access through a proxy) or without the prefix entirely (e.g., mimicking local access or by a proxy itself).
+
+    Note: We test the OpenAPI schema as well because when the root path is not set correctly,
+    the docs break from failure to fetch openapi.json.
+    (https://fastapi.tiangolo.com/advanced/behind-a-proxy/#proxy-with-a-stripped-path-prefix)
+    """
+
+    monkeypatch.setattr(app, "root_path", "/upload")
+    docs_response = test_app.get(f"{test_path}/docs", follow_redirects=False)
+    schema_response = test_app.get(
+        f"{test_path}/openapi.json", follow_redirects=False
+    )
+    assert docs_response.status_code == expected_status_code
+    assert schema_response.status_code == expected_status_code
+
+
+@pytest.mark.parametrize(
+    "test_path,expected_status_code",
+    [("", 200), ("/upload/", 200), ("/upload", 404)],
+)
+def test_docs_when_root_path_includes_trailing_slash(
+    test_app, test_path, expected_status_code, monkeypatch
+):
+    """
+    Test that when the API root_path is set with a trailing slash, the interactive docs and OpenAPI schema are only reachable
+    using a path prefix with the extra trailing slash also included, or without the prefix entirely.
+
+    This provides a sanity check that the app does not ignore/redirect trailing slashes in the root_path when requests are received.
+    """
+
+    monkeypatch.setattr(app, "root_path", "/upload")
+    docs_response = test_app.get(f"{test_path}/docs", follow_redirects=False)
+    schema_response = test_app.get(
+        f"{test_path}/openapi.json", follow_redirects=False
+    )
+    assert docs_response.status_code == expected_status_code
+    assert schema_response.status_code == expected_status_code


### PR DESCRIPTION
<!--- Until this PR is ready for review, you can include [WIP] in the title, or create a draft PR. -->


<!---
Below is a suggested pull request template. Feel free to add more details you feel are relevant/necessary.

For more info on the Neurobagel PR process and other contributing guidelines, see https://neurobagel.org/contributing/CONTRIBUTING/.
-->

<!-- 
Please indicate after the # which issue you're closing with this PR, if applicable.
If the PR closes multiple issues, include "closes" before each one is listed.
You can also link to other issues if necessary, e.g. "See also #1234".

https://help.github.com/articles/closing-issues-using-keywords
-->
- Closes #35 

<!-- 
Please give a brief overview of what has changed or been added in the PR.
This can include anything specific the maintainers should be looking for when they review the PR.
-->
Changes proposed in this pull request:

- Make root path for the FastAPI app configurable via an optional environment variable `NB_UPLOADER_API_ROOT_PATH`
    - Meant for use in deployment scenarios with proxy servers that use a stripped path prefix
- Upgrade fastapi to 0.115.4 to keep behaviour of root path prefix setting consistent with [f-API](https://github.com/neurobagel/federation-api/pull/154) and [n-API](https://github.com/neurobagel/api/pull/400)
    - Something about the `root_path` behaviour changed in [0.109.0](https://fastapi.tiangolo.com/release-notes/#01090) (see for example https://github.com/fastapi/fastapi/issues/10978) - this is not super well documented, but may be related to the Starlette dependency upgrade
    - for <0.109.0, API docs paths are not locally reachable at all when the root path prefix is set, unless accessing via proxy using the path prefix

Housekeeping:
- Update README badges for org consistency


<!-- To be checked off by reviewers -->
## Checklist
_This section is for the PR reviewer_

- [x] PR has an interpretable title with a prefix (`[ENH]`, `[FIX]`, `[REF]`, `[TST]`, `[CI]`, `[MNT]`, `[INF]`, `[MODEL]`, `[DOC]`) _(see our [Contributing Guidelines](https://neurobagel.org/contributing/CONTRIBUTING#pull-request-guidelines) for more info)_
- [x] PR has a label for the release changelog or `skip-release` (to be applied by maintainers only)
- [x] PR links to GitHub issue with mention `Closes #XXXX`
- [x] Tests pass
- [x] Checks pass

For new features:
- [x] Tests have been added

For bug fixes:
- [ ] There is at least one test that would fail under the original bug conditions.
